### PR TITLE
Add support for static freezed resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,45 @@ GET myproject.dev/?patch=feature1;feature2
 2: data/patch/feature2.js
 ```
 
+## Заморозка статики
+
+Прокси умеет отдавать правильные ссылки на замороженые ресурсы используя json карту соответсвия.
+Для указания файла с картой используется переменная окружения `FREEZE_MAP` с указанием пути до карты относительно корня проекта.
+переменная окружения `NORMALIZE_FREEZE_URLS` позволяет использовать карту с windows путями, однако добавляет оверхед.
+Не рекомендуется использовать эту опцию в production окружении
+
+### Генерация карты кода
+
+Для генерации карты можно использовать `borschik`:
+
+```bash
+$ borschik freeze --input=js > freeze-info.json
+```
+
+Подробнее в документации к [borschik](https://github.com/bem-site/bem-method/blob/bem-info-data/articles/borschik/borschik.ru.md#Полная-заморозка)
+
+### Использование в шаблонах
+
+В BEMTREE становится доступна функция `getFreezed()`
+
+Пример:
+
+```javascript
+// FREEZEMAP
+{
+    "my-scripts/long/link/index.min.js" : "./freezed/_/dsdgjlka342jfsgjslkgjs41jgls1k8gjslkgs.js"
+}
+
+// BEMTREE
+block('page')(
+    content()((node, ctx) => [{
+        scripts: [{ elem: 'js', url: node.getFreezed('my-scripts/long/link/index.min.js') }],
+    }])
+)
+
+// BEMJSON
+{
+    block : 'page'
+    scripts: [{ elem: 'js', url: './freezed/_/dsdgjlka342jfsgjslkgjs41jgls1k8gjslkgs.js' }],
+}
+```

--- a/freeze-map.js
+++ b/freeze-map.js
@@ -1,0 +1,37 @@
+class FreezeMapper {
+    get winRegexp() { return new RegExp('\\\\', 'g')}
+    get unixRegexp() { return new RegExp('/', 'g')}
+
+    constructor(path2map = {}, normalize = false){
+        this._isNeedNormalize = normalize;
+        this._map = path2map;
+    }
+
+    /**
+     * Ищет соответствие в карте фризов для переданного url
+     * @public
+     * @param {String} url - ссылка на ресурс
+     * @return {String} ссылка на замороженый ресурс
+     */
+    linkTo(url){
+        if(this._isNeedNormalize) {
+            let key = this._unix2win(url);
+            if(this._map[key]) {
+                return this._win2unix(this._map[key]);
+            }
+            return url;
+        }
+
+        return this._map[url] || unfreezed;
+    }
+
+    _unix2win(url) {
+        return url.replace(this.unixRegexp, '\\');
+    }
+
+    _win2unix(url) {
+        return url.replace(this.winRegexp, '/');
+    }
+};
+
+module.exports = FreezeMapper;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author" : "Evgeniy Baranov <master@kompolom.ru>",
   "name": "bem-render-proxy",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Render proxy for bem projects. Render data with BEMHTML and BEMTREE",
   "main": "index.js",
   "repository" : "https://github.com/kompolom/bem-render-proxy",


### PR DESCRIPTION
Добавляет возможность использовать маппинг статических ресурсов.
Добавлена переменная окружения `FREEZE_MAP` c путем до карты ресурсов относительно корня проекта.
Добавлена переменная окружения `CONVERT_WINDOWS_SLASHES` включает ковертирование путей в карте сгенерированой под windows. Полезно для разработки, но добавляет оверхед.
Карту ресурсов можно составить с побощью `borschik freeze`