### PR TITLE
Auto-drop шаблонов в local режиме

### DIFF
--- a/render.js
+++ b/render.js
@@ -61,6 +61,9 @@ function render(req, res, data, context) {
         if(APP_ENV == 'local' && query.rebuild) {
             var exec = require('child_process').execSync;
             exec('./node_modules/.bin/enb make ' + bundle.bundle, { stdio : [0,1,2] });
+        }
+
+        if(APP_ENV === 'local') {
             console.log('Drop templates cache');
             delete require.cache[require.resolve(bemtreePath)];
             delete require.cache[require.resolve(bemhtmlPath)];


### PR DESCRIPTION
Полезно при сборке проекта через `enb` и другие инструменты. На каждый запрос в `local` шаблоны будут автоматически переподключаться.

Вот несколько кейсов, которые это покрывает:
1. Когда мы собираем проект через команду `enb make`
2. Когда мы дебажим собранный бандл (поправили что-то в собранном бандле, перезагрузили страницу).