### PR TITLE
Исправление обработки ответа от бэкенда

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,9 @@ app.all('*', function(req, res) {
         var needRender = !!backendMessage.headers['x-render'] || backendMessage.headers['content-type'] === renderContentType,
             body = '';
 
+        // Для правильного разбиения чанков
+        backendMessage.setEncoding('utf8');
+
         if(!needRender){
             res.writeHead(backendMessage.statusCode, backendMessage.headers);
             backendMessage.on('data', (chunk) => {res.write(chunk);});


### PR DESCRIPTION
Нода почему-то неправильно определяет как нужно разбивать стрим на чанки (хотя по-умолчанию вроде в `utf8` должна работать), в результате чего в русских символах появляются "ромбики". 

Установка "захардкожена", т.к. по стандарту JSON должен быть в кодировке UTF-8
http://www.ietf.org/rfc/rfc4627.txt