### PR TITLE
Добавление json-cut

### DIFF
--- a/json-cut.js
+++ b/json-cut.js
@@ -1,0 +1,16 @@
+module.exports = function(data, path) {
+    if(!path || path === '1')
+        return data
+
+    const steps = path.split(/[\[\]\.]/);
+
+    let result = data;
+    steps.forEach((step) => {
+        if(step === '')
+            return;
+
+        result = result[step];
+    });
+
+    return result;
+}

--- a/render.js
+++ b/render.js
@@ -55,7 +55,11 @@ function render(req, res, data, context) {
 
     recordRenderTime.call(req);
 
-    if(DEBUG && query.json) return res.send('<pre>' + JSON.stringify(data, null, 4) + '</pre>');
+    if(DEBUG && query.json) {
+        let json = require('./json-cut')(data, query.json);
+
+        return res.send('<pre>' + JSON.stringify(json, null, 4) + '</pre>');
+    }
 
     try {
         var bemtreePath = bundle.getFile('bemtree.js', data.lang),


### PR DESCRIPTION
По флагу `json` позволяет отдавать точечные данные

Например:
```
{ a : { b : { c : [1,2,3] }}
```

`&json=a.b.c[1]`

Вернёт `2`